### PR TITLE
Separate PutItem and UpdateItem in DynamoDbStorage

### DIFF
--- a/src/Domainator.Aws.Infrastructure/Repositories/StateManagement/Storage/DynamoDbAggregateStateStorage.cs
+++ b/src/Domainator.Aws.Infrastructure/Repositories/StateManagement/Storage/DynamoDbAggregateStateStorage.cs
@@ -139,11 +139,11 @@ namespace Domainator.Infrastructure.Repositories.StateManagement.Storage
             {
                 if (version == AggregateVersion.Emtpy)
                 {
-                    await PutItemAsync(cancellationToken, document);
+                    await PutItemAsync(document, cancellationToken);
                 }
                 else
                 {
-                    await UpdateItemAsync(version, cancellationToken, document);
+                    await UpdateItemAsync(version, document, cancellationToken);
                 }
 
             }
@@ -155,8 +155,7 @@ namespace Domainator.Infrastructure.Repositories.StateManagement.Storage
             }
         }
 
-        private async Task UpdateItemAsync(AggregateVersion version, CancellationToken cancellationToken,
-            Document document)
+        private async Task UpdateItemAsync(AggregateVersion version,Document document, CancellationToken cancellationToken)
         {
             var updateConfig = new UpdateItemOperationConfig();
             updateConfig.ExpectedState = new ExpectedState();
@@ -165,7 +164,7 @@ namespace Domainator.Infrastructure.Repositories.StateManagement.Storage
             await _dynamoDbTable.UpdateItemAsync(document, updateConfig, cancellationToken);
         }
 
-        private async Task PutItemAsync(CancellationToken cancellationToken, Document document)
+        private async Task PutItemAsync(Document document, CancellationToken cancellationToken)
         {
             var putConfig = new PutItemOperationConfig();
             putConfig.ExpectedState = new ExpectedState();

--- a/tests/Domainator.Aws.IntegrationTests/Domainator.Aws.IntegrationTests.csproj
+++ b/tests/Domainator.Aws.IntegrationTests/Domainator.Aws.IntegrationTests.csproj
@@ -8,6 +8,7 @@
     <ItemGroup>
       <PackageReference Include="AutoFixture.AutoMoq" Version="4.11.0" />
       <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
+      <PackageReference Include="FluentAssertions" Version="5.10.3" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
       <PackageReference Include="xunit" Version="2.4.0" />
       <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />

--- a/tests/Domainator.Aws.IntegrationTests/Repositories/StateManagement/Storage/DynamoDbAggregateStateStorageTests.cs
+++ b/tests/Domainator.Aws.IntegrationTests/Repositories/StateManagement/Storage/DynamoDbAggregateStateStorageTests.cs
@@ -210,7 +210,7 @@ namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
             TodoTask.AggregateState state = new TodoTask.AggregateState();
             state.Mutate(new TodoTaskCreated(projectId, taskId));
             await _stateStorage.PersistAsync(taskId, state, AggregateVersion.Emtpy, new Dictionary<string, object>(), CancellationToken.None);
-            var ( createdAt1, updatedAt1) = await GetAuditDatesAsync(taskId);
+            var (createdAt1, updatedAt1) = await GetAuditDatesAsync(taskId);
 
             var (newVersion, newState) = await _stateStorage.LoadAsync<TodoTask.AggregateState>(taskId, CancellationToken.None);
             newState.Mutate(new TodoTaskCompleted(taskId));
@@ -221,7 +221,7 @@ namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
             Assert.Equal(createdAt1, createdAt2);
             Assert.True(updatedAt2 > updatedAt1);
             createdAt1.Should().BeCloseTo(DateTimeOffset.UtcNow, 1000);
-            createdAt1.Should().BeCloseTo(DateTimeOffset.UtcNow, 500);
+            updatedAt2.Should().BeCloseTo(DateTimeOffset.UtcNow, 500);
         }
 
         private async Task<(DateTimeOffset, DateTimeOffset)> GetAuditDatesAsync(TodoTaskId taskId)

--- a/tests/Domainator.Aws.IntegrationTests/Repositories/StateManagement/Storage/DynamoDbAggregateStateStorageTests.cs
+++ b/tests/Domainator.Aws.IntegrationTests/Repositories/StateManagement/Storage/DynamoDbAggregateStateStorageTests.cs
@@ -1,12 +1,15 @@
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using Amazon.DynamoDBv2.DocumentModel;
 using AutoFixture;
 using AutoFixture.Xunit2;
 using Domainator.Demo.Domain.Domain;
 using Domainator.Entities;
 using Domainator.Infrastructure.Repositories.StateManagement.Serialization.Json;
 using Domainator.Infrastructure.Repositories.StateManagement.Storage;
+using FluentAssertions;
 using Xunit;
 
 namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
@@ -14,12 +17,14 @@ namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
     public class DynamoDbAggregateStateStorageTests : IClassFixture<AggregateStoreDynamoDbTableFixture>
     {
         private readonly IAggregateStateStorage _stateStorage;
+        private readonly Table _storageTable;
 
         public DynamoDbAggregateStateStorageTests(AggregateStoreDynamoDbTableFixture fixture)
         {
             _stateStorage = new DynamoDbAggregateStateStorage(
                 fixture.StoreTable,
                 new AggregateStateJsonSerializer());
+            _storageTable = fixture.StoreTable;
         }
 
         [Theory]
@@ -35,17 +40,20 @@ namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
 
         [Theory]
         [DynamoDbAggregateStateStorageTestsData]
-        public async Task LoadAsync_CanReadPersistedState(TodoTaskId id, AggregateVersion originalVersion, TodoTask.AggregateState state)
+        public async Task LoadAsync_CanReadPersistedState(TodoTaskId id, TodoTask.AggregateState state)
         {
             // arrange
-            await _stateStorage.PersistAsync(id, state, originalVersion, new Dictionary<string, object>(), CancellationToken.None);
+            state.Mutate(new TodoTaskCompleted(id));
+            await _stateStorage.PersistAsync(id, state, AggregateVersion.Emtpy, new Dictionary<string, object>(),
+                CancellationToken.None);
 
             // act
-            var (restoredVersion, restoredState) = await _stateStorage.LoadAsync<TodoTask.AggregateState>(id, CancellationToken.None);
+            var (restoredVersion, restoredState) =
+                await _stateStorage.LoadAsync<TodoTask.AggregateState>(id, CancellationToken.None);
 
             // assert
             Assert.Equal(state.ProjectId, restoredState.ProjectId);
-            Assert.Equal(originalVersion, restoredVersion);
+            Assert.Equal(AggregateVersion.Emtpy.Increment(), restoredVersion);
         }
 
         [Theory]
@@ -59,29 +67,32 @@ namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
             // arrange
             state.Mutate(todoTaskCreated);
 
-            await _stateStorage.PersistAsync(id, state, originalVersion, new Dictionary<string, object>(), CancellationToken.None);
+            await _stateStorage.PersistAsync(id, state, AggregateVersion.Emtpy, new Dictionary<string, object>(),
+                CancellationToken.None);
 
             // act
-            var (restoredVersion, restoredState) = await _stateStorage.LoadAsync<TodoTask.AggregateState>(id, CancellationToken.None);
+            var (restoredVersion, restoredState) =
+                await _stateStorage.LoadAsync<TodoTask.AggregateState>(id, CancellationToken.None);
 
             // assert
             Assert.Equal(state.ProjectId, restoredState.ProjectId);
-            Assert.Equal(originalVersion.Increment(), restoredVersion);
+            Assert.Equal(AggregateVersion.Emtpy.Increment(), restoredVersion);
         }
 
         [Theory]
         [DynamoDbAggregateStateStorageTestsData]
         public async Task LoadAsync_WhenStageWasUpdatedConcurrently_Throws(
             TodoTaskId id,
-            AggregateVersion originalVersion,
             TodoTask.AggregateState state)
         {
             // arrange
-            await _stateStorage.PersistAsync(id, state, originalVersion.Increment(), new Dictionary<string, object>(), CancellationToken.None);
+            await _stateStorage.PersistAsync(id, state, AggregateVersion.Emtpy, new Dictionary<string, object>(),
+                CancellationToken.None);
 
             // act && assert
             await Assert.ThrowsAsync<StateWasConcurrentlyUpdatedException>(
-                () => _stateStorage.PersistAsync(id, state, originalVersion, new Dictionary<string, object>(), CancellationToken.None));
+                () => _stateStorage.PersistAsync(id, state, AggregateVersion.Emtpy.Increment(),
+                    new Dictionary<string, object>(), CancellationToken.None));
         }
 
         [Theory]
@@ -98,20 +109,22 @@ namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
             foreach (var id in ids)
             {
                 var state = fixture.Create<TodoTask.AggregateState>();
-                var version = fixture.Create<AggregateVersion>();
+                state.Mutate(new TodoTaskCreated(projectId, id));
+                var version = AggregateVersion.Emtpy;
                 states[id] = (version, state);
 
                 await _stateStorage.PersistAsync(
                     id,
                     state,
                     version,
-                    new Dictionary<string, object> {{ attributeName, projectId }},
+                    new Dictionary<string, object> {{attributeName, projectId}},
                     CancellationToken.None);
             }
 
             // act
             var query = new FindByAttributeValueStateQuery(attributeName, projectId, ids.Length);
-            var queryResult = await _stateStorage.FindByAttributeValueAsync<TodoTask.AggregateState>(query, CancellationToken.None);
+            var queryResult =
+                await _stateStorage.FindByAttributeValueAsync<TodoTask.AggregateState>(query, CancellationToken.None);
 
             // assert
             foreach (var id in ids)
@@ -119,7 +132,7 @@ namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
                 var (actualVersion, actualState) = states[id];
                 var (restoredVersion, restoredState) = queryResult.States[id];
 
-                Assert.Equal(actualVersion, restoredVersion);
+                Assert.Equal(AggregateVersion.Emtpy.Increment(), restoredVersion);
                 Assert.Equal(actualState.ProjectId, restoredState.ProjectId);
                 Assert.Equal(actualState.TaskState, restoredState.TaskState);
             }
@@ -139,39 +152,43 @@ namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
             foreach (var id in ids)
             {
                 var state = fixture.Create<TodoTask.AggregateState>();
-                var version = fixture.Create<AggregateVersion>();
+                var version = AggregateVersion.Emtpy;
                 states[id] = (version, state);
 
                 await _stateStorage.PersistAsync(
                     id,
                     state,
                     version,
-                    new Dictionary<string, object> {{ attributeName, projectId }},
+                    new Dictionary<string, object> {{attributeName, projectId}},
                     CancellationToken.None);
             }
 
             // act
-            var results = new Dictionary<IEntityIdentity, (AggregateVersion, TodoTask.AggregateState)>(EntityIdentity.DefaultComparer);
+            var results =
+                new Dictionary<IEntityIdentity, (AggregateVersion, TodoTask.AggregateState)>(EntityIdentity
+                    .DefaultComparer);
             FindByAttributeValueStateQueryResult<TodoTask.AggregateState> queryResult = null;
             do
             {
                 FindByAttributeValueStateQuery query;
                 if (queryResult != null)
                 {
-                    query = new FindByAttributeValueStateQuery(attributeName, projectId, 2, queryResult.PaginationToken);
+                    query = new FindByAttributeValueStateQuery(attributeName, projectId, 2,
+                        queryResult.PaginationToken);
                 }
                 else
                 {
                     query = new FindByAttributeValueStateQuery(attributeName, projectId, 2);
                 }
 
-                queryResult = await _stateStorage.FindByAttributeValueAsync<TodoTask.AggregateState>(query, CancellationToken.None);
+                queryResult =
+                    await _stateStorage.FindByAttributeValueAsync<TodoTask.AggregateState>(query,
+                        CancellationToken.None);
                 foreach (var pair in queryResult.States)
                 {
                     results[pair.Key] = pair.Value;
                 }
-            }
-            while (queryResult.PaginationToken != null);
+            } while (queryResult.PaginationToken != null);
 
             // assert
             foreach (var id in ids)
@@ -183,6 +200,43 @@ namespace Domainator.Aws.IntegrationTests.Repositories.StateManagement.Storage
                 Assert.Equal(actualState.ProjectId, restoredState.ProjectId);
                 Assert.Equal(actualState.TaskState, restoredState.TaskState);
             }
+        }
+
+        [Theory]
+        [DynamoDbAggregateStateStorageTestsData]
+        public async Task PersistedAsync_ShouldStoreCreatedAtAndUpdatedAt(TodoTaskId taskId, ProjectId projectId)
+        {
+            // arrange & act
+            TodoTask.AggregateState state = new TodoTask.AggregateState();
+            state.Mutate(new TodoTaskCreated(projectId, taskId));
+            await _stateStorage.PersistAsync(taskId, state, AggregateVersion.Emtpy, new Dictionary<string, object>(), CancellationToken.None);
+            var ( createdAt1, updatedAt1) = await GetAuditDatesAsync(taskId);
+
+            var (newVersion, newState) = await _stateStorage.LoadAsync<TodoTask.AggregateState>(taskId, CancellationToken.None);
+            newState.Mutate(new TodoTaskCompleted(taskId));
+            await _stateStorage.PersistAsync(taskId, newState, newVersion, new Dictionary<string, object>(), CancellationToken.None);
+            var ( createdAt2, updatedAt2) = await GetAuditDatesAsync(taskId);
+
+            // assert
+            Assert.Equal(createdAt1, createdAt2);
+            Assert.True(updatedAt2 > updatedAt1);
+            createdAt1.Should().BeCloseTo(DateTimeOffset.UtcNow, 1000);
+            createdAt1.Should().BeCloseTo(DateTimeOffset.UtcNow, 500);
+        }
+
+        private async Task<(DateTimeOffset, DateTimeOffset)> GetAuditDatesAsync(TodoTaskId taskId)
+        {
+            var getConfig = new GetItemOperationConfig {ConsistentRead = true};
+            var primaryKey = taskId.Tag + "_" + taskId.Value;
+            const string headSortKeyValue = "HEAD";
+
+            var document = await _storageTable.GetItemAsync(primaryKey, headSortKeyValue, getConfig,
+                CancellationToken.None);
+
+            var createdAt1 = DateTimeOffset.FromUnixTimeMilliseconds((long)document["CreatedAt"]);
+            var modifiedAt1 = DateTimeOffset.FromUnixTimeMilliseconds((long)document["UpdatedAt"]);
+
+            return (createdAt1, modifiedAt1);
         }
     }
 }


### PR DESCRIPTION
This PR aims to fix a bug when updating existing aggregate, CreatedAt is overridden to empty.